### PR TITLE
Fix spelling issue

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: language-elm
-version: '0.1.1.1'
+version: '0.2.0.0'
 synopsis: Generate elm code
 description: Generate elm code from an ast
 category: Web
@@ -21,7 +21,7 @@ library:
   source-dirs: src
   exposed-modules:
   - Elm
-  - Elm.Decleration
+  - Elm.Declaration
   - Elm.Expression 
   - Elm.Import
   - Elm.Program

--- a/src/Elm.hs
+++ b/src/Elm.hs
@@ -28,7 +28,7 @@ module Elm
     , ttuple
     , trecord
     , trecordParam
-    -- * Declerations
+    -- * Declarations
     , Dec
     , decVariable
     , decFunction
@@ -61,7 +61,7 @@ import           Protolude            hiding (Type, bool, list)
 import           Control.Monad.Writer
 import           Data.String
 import           Elm.Classes
-import qualified Elm.Decleration
+import qualified Elm.Declaration
 import qualified Elm.Expression
 import           Elm.GenError         (GenError (WarningList))
 import qualified Elm.Import
@@ -72,7 +72,7 @@ import Prelude (error)
 
 type Expr = Elm.Expression.Expr
 type Type = Elm.Type.TypeDec
-type Dec = Elm.Decleration.Dec
+type Dec = Elm.Declaration.Dec
 type Import = Elm.Import.Import
 type ImportExpr = Elm.Import.ImportType
 type ImportItem = Elm.Import.ImportItem
@@ -231,7 +231,7 @@ decVariable :: String -- ^ The variable name
     -> Type -- ^ The variable's type
     -> Expr -- ^ The variable's value
     -> Dec
-decVariable name type_ expr = Elm.Decleration.Dec  name type_ [] expr
+decVariable name type_ expr = Elm.Declaration.Dec  name type_ [] expr
 
 -- | Declare a function
 decFunction :: String  -- ^ The function name
@@ -239,21 +239,21 @@ decFunction :: String  -- ^ The function name
     -> [Expr] -- ^ The fuction's paramaters
     -> Expr  -- ^ The function's value
     -> Dec
-decFunction = Elm.Decleration.Dec
+decFunction = Elm.Declaration.Dec
 
 -- | Declare a type
 decType :: String -- ^ The type name
     -> [String] -- ^ The type's type paramaters
     -> [(String, [Type])] -- ^ The type's constructors
     -> Dec
-decType = Elm.Decleration.DecType
+decType = Elm.Declaration.DecType
 
 -- | Declare a type alias
 decTypeAlias :: String  -- ^ The type alias' name
     -> [String]  -- ^ The type alias's type paramaters
     -> Type  -- ^ The type alias's type
     -> Dec
-decTypeAlias = Elm.Decleration.DecTypeAlias
+decTypeAlias = Elm.Declaration.DecTypeAlias
 
 -- | Import an item
 select :: String -> ImportItem

--- a/src/Elm/Declaration.hs
+++ b/src/Elm/Declaration.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE Safe              #-}
 
 -- | Top level declerations
-module Elm.Decleration where
+module Elm.Declaration where
 
 import           Elm.Classes
 import           Elm.Expression

--- a/src/Elm/Program.hs
+++ b/src/Elm/Program.hs
@@ -14,7 +14,7 @@ import           Data.List            hiding (map)
 import           Data.String
 import           Data.String.Utils
 import           Elm.Classes
-import           Elm.Decleration
+import           Elm.Declaration
 import           Elm.GenError
 import           Elm.Import
 import           Text.PrettyPrint

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -2,7 +2,7 @@
 
 import           Control.Monad.Writer
 import           Elm.Classes
-import           Elm.Decleration
+import           Elm.Declaration
 import           Elm.Expression
 import           Elm.GenError
 import           Elm.Import


### PR DESCRIPTION
Fix the spelling of `Elm.Declaration` (was `Elm.Decleration`)

Technically this is a major change :roll_eyes: 